### PR TITLE
removing Anaconda navigator, and defaults channel

### DIFF
--- a/MacOS/Python/Install.sh
+++ b/MacOS/Python/Install.sh
@@ -72,18 +72,26 @@ eval "$($brew_path shellenv)"
 hash -r 
 clear -x
 
+echo "Removing defaults channel (due to licensing problems)"
+conda config --add channels conda-forge
+conda config --remove channels defaults
+
+
 echo "Downgrading python version to ${_py_version}..."
 conda install python=${_py_version} -y
 [ $? -ne 0 ] && exit_message
 clear -x 
 
-# Install anaconda GUI
-echo "Installing Anaconda Navigator GUI"
-conda install anaconda-navigator -y
-[ $? -ne 0 ] && exit_message
+# We will not install the Anaconda GUI
+# There may be license issues due to DTU being
+# a rather big institution. So our installation guides
+# Will be pre-cautious here, and remove the defaults channels.
+#echo "Installing Anaconda Navigator GUI"
+#conda install anaconda-navigator -y
+#[ $? -ne 0 ] && exit_message
 
 echo "Installing packages..."
-conda install -c conda-forge dtumathtools uncertainties -y
+conda install dtumathtools uncertainties -y
 [ $? -ne 0 ] && exit_message
 clear -x
 

--- a/MacOS/VSC/Install.sh
+++ b/MacOS/VSC/Install.sh
@@ -15,7 +15,6 @@ url_ps="https://raw.githubusercontent.com/$REMOTE_PS/$BRANCH_PS/MacOS"
 
 
 
-
 # Check for homebrew
 # if not installed call homebrew installation script
 if ! command -v brew > /dev/null; then
@@ -85,3 +84,4 @@ code --install-extension tomoki1207.pdf
 
 echo ""
 echo "Script has finished. You may now close the terminal..."
+

--- a/Windows/Python/Install.ps1
+++ b/Windows/Python/Install.ps1
@@ -118,6 +118,17 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
         Exit-Message
     }
 
+    # Ensuring correct channels are set
+    Write-Host "Removing defaults channel (due to licensing problems)"
+    & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" config --add channels conda-forge
+    if (-not $?) {
+        Exit-Message
+    }
+    & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" config --remove channels defaults
+    if (-not $?) {
+        Exit-Message
+    }
+
     # Ensure version of Python
     Write-Host "Updating Python to version $env:PYTHON_VERSION_PS..."
     & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" install python=$env:PYTHON_VERSION_PS -y
@@ -127,16 +138,20 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
         Exit-Message
     }
 
+    # We will not install the Anaconda GUI
+    # There may be license issues due to DTU being
+    # a rather big institution. So our installation guides
+    # Will be pre-cautious here, and remove the defaults channels.
     # Install the GUI (Anaconda Navigator)
-    & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" install anaconda-navigator -y
-    if ($?) {
-        Write-Host "Anaconda Navigator installed."
-    } else {
-        Exit-Message
-    }
+    #& "$env:USERPROFILE\Miniconda3\condabin\conda.bat" install anaconda-navigator -y
+    #if ($?) {
+    #    Write-Host "Anaconda Navigator installed."
+    #} else {
+    #    Exit-Message
+    #}
 
     # Install packages
-    & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" install -c conda-forge dtumathtools uncertainties -y
+    & "$env:USERPROFILE\Miniconda3\condabin\conda.bat" install dtumathtools uncertainties -y
     if ($?) {
         Write-Host "Additional packages installed."
     } else {


### PR DESCRIPTION
Now conda-forge is the only viable channel to fetch resources from.