### PR TITLE
streamlined mac and win + enabled return codes

### DIFF
--- a/MacOS/Python/Install.sh
+++ b/MacOS/Python/Install.sh
@@ -7,13 +7,17 @@ fi
 if [ -z "$BRANCH_PS" ]; then
   BRANCH_PS="main"
 fi
+if [ -z "$PYTHON_VERSION_PS" ]; then
+  PYTHON_VERSION_PS="3.11"
+fi
 
 export REMOTE_PS
 export BRANCH_PS
 
-# set URL
-url_ps="https://raw.githubusercontent.com/$REMOTE_PS/$BRANCH_PS/MacOS"
 
+_py_version=$PYTHON_VERSION_PS
+
+url_ps="https://raw.githubusercontent.com/$REMOTE_PS/$BRANCH_PS/MacOS"
 
 echo "$_prefix Python installation"
 
@@ -29,7 +33,7 @@ if ! command -v brew > /dev/null; then
   [ -e ~/.bash_profile ] && source ~/.bash_profile
 
   # update binary locations 
-  hash -r 
+  hash -r
 fi
 
 
@@ -53,16 +57,8 @@ exit_message () {
 }
 
 
-
-if [ -z "$PYTHON_VERSION_PS" ]; then
-    PYTHON_VERSION_PS="3.11"
-fi
-
-_py_version=$PYTHON_VERSION_PS
-
 # Install miniconda
 # Check if miniconda is installed
-
 echo "$_prefix Installing Miniconda..."
 if conda --version > /dev/null; then
   echo "$_prefix Miniconda or anaconda is already installed"
@@ -74,7 +70,7 @@ fi
 clear -x
 
 echo "$_prefix Initialising conda..."
-conda init bash 
+conda init bash
 [ $? -ne 0 ] && exit_message
 
 conda init zsh
@@ -89,7 +85,8 @@ echo "$_prefix Showing where it is installed:"
 conda info --base
 [ $? -ne 0 ] && exit_message
 
-hash -r 
+echo "$_prefix Updating environment variables"
+hash -r
 clear -x
 
 echo "$_prefix Removing defaults channel (due to licensing problems)"

--- a/MacOS/VSC/Install.sh
+++ b/MacOS/VSC/Install.sh
@@ -68,7 +68,7 @@ else
     [ $? -ne 0 ] && exit_message
 fi
 
-hash -r 
+hash -r
 clear -x
 
 
@@ -85,9 +85,8 @@ fi
 clear -x
 
 echo "$_prefix Installing extensions for Visual Studio Code..."
-# install extensions for vs code
-# install python extension, jupyter, vscode-pdf
-#python extension
+
+# install python extension
 code --install-extension ms-python.python
 [ $? -ne 0 ] && exit_message
 

--- a/MacOS_AutoInstall.sh
+++ b/MacOS_AutoInstall.sh
@@ -1,4 +1,6 @@
-# checks for environmental variables for remote and branch 
+_prefix="PYS:"
+
+# checks for environmental variables for remote and branch
 if [ -z "$REMOTE_PS" ]; then
   REMOTE_PS="dtudk/pythonsupport-scripts"
 fi
@@ -9,20 +11,35 @@ fi
 export REMOTE_PS
 export BRANCH_PS
 
-# set URL
 url_ps="https://raw.githubusercontent.com/$REMOTE_PS/$BRANCH_PS/MacOS"
 
-# echo url for debugging
-echo "URL used for fetching scripts $url_ps"
+echo "$_prefix URL used for fetching scripts $url_ps"
 
 # install python
 /bin/bash -c "$(curl -fsSL $url_ps/Python/Install.sh)"
+_python_ret=$?
 
 # install vscode
 /bin/bash -c "$(curl -fsSL $url_ps/VSC/Install.sh)"
+_vsc_ret=$?
+
+
+exit_message() {
+  echo ""
+  echo "Something went wrong in one of the installation runs."
+  echo "Please see further up in the output for an error message..."
+  echo ""
+}
+
+if [ $_python_ret -ne 0 ]; then
+  exit_message
+  exit $_python_ret
+elif [ $_vsc_ret -ne 0 ]; then
+  exit_message
+  exit $_vsc_ret
+fi
 
 clear -x
 
 echo ""
 echo "Script has finished. You may now close the terminal..."
-

--- a/MacOS_AutoInstall.sh
+++ b/MacOS_AutoInstall.sh
@@ -39,7 +39,6 @@ elif [ $_vsc_ret -ne 0 ]; then
   exit $_vsc_ret
 fi
 
-clear -x
-
+echo ""
 echo ""
 echo "Script has finished. You may now close the terminal..."

--- a/Windows/Python/Install.ps1
+++ b/Windows/Python/Install.ps1
@@ -1,11 +1,12 @@
 $_prefix = "PYS:"
 
-# check for env variable PYTHONVERSIONPS 
+# check for env variable PYTHON_VERSION_PS
 # if it isn't set set it to 3.11
-
 if (-not $env:PYTHON_VERSION_PS) {
     $env:PYTHON_VERSION_PS = "3.11"
 }
+
+Write-Output "$_prefix Python installation"
 
 
 # Function to refresh environment variables in the current session
@@ -59,18 +60,14 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
 
     Write-Output "$_prefix Downloading installer for Miniconda..."
     Invoke-WebRequest -Uri $minicondaUrl -OutFile $minicondaInstallerPath
-    if ($?) {
-        Write-Output "$_prefix Miniconda installer downloaded."
-    } else {
+    if (-not $?) {
         Exit-Message
     }
 
     Write-Output "$_prefix Installing Miniconda..."
     # Install Miniconda
     Start-Process -FilePath $minicondaInstallerPath -ArgumentList "/InstallationType=JustMe /RegisterPython=1 /S /D=$env:USERPROFILE\Miniconda3" -Wait
-    if ($?) {
-        Write-Output "$_prefix Miniconda installed."
-    } else {
+    if (-not $?) {
         Exit-Message
     }
 
@@ -90,14 +87,13 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
         }
     }
 
+
+    Write-Output "$_prefix Environment variables refreshed."
     Add-CondaToPath
     Refresh-Env
-    if ($?) {
-        Write-Output "$_prefix Environment variables refreshed."
-    } else {
+    if (-not $?) {
         Exit-Message
     }
-
 
     # Check conda-paths
     $conda_paths = Get-Command -ErrorAction:SilentlyContinue conda
@@ -131,7 +127,6 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
     $condaBatPath = "$env:USERPROFILE\Miniconda3\condabin\conda.bat"
 
 
-
     # Ensuring correct channels are set
     Write-Output "$_prefix Removing defaults channel (due to licensing problems)"
     & $condaBatPath config --add channels conda-forge
@@ -144,12 +139,14 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
     if (-not $?) {
        Write-Output "$_prefix Failed to remove defaults channel"
     }
+    # Forcefully try to always use conda-forge
     & $condaBatPath config --set channel_priority strict
     if (-not $?) {
         Exit-Message
     }
-     # Ensures correct version of python
 
+
+    # Ensures correct version of python
     if (-not $env:PYTHON_INSTALL_COMMAND_EXECUTED) {
         & $condaBatPath install python=$env:PYTHON_VERSION_PS -y
         $env:PYTHON_INSTALL_COMMAND_EXECUTED = "true"
@@ -160,9 +157,8 @@ if ((Test-Path $minicondaPath1) -or (Test-Path $minicondaPath2) -or (Test-Path $
         Exit-Message
     }
 
-   
-   # Install packages
-        
+
+    # Install packages
     Write-Output "$_prefix Installing packages..."
     & $condaBatPath install dtumathtools pandas scipy statsmodels uncertainties -y
     if (-not $?) {

--- a/Windows/VSC/Install.ps1
+++ b/Windows/VSC/Install.ps1
@@ -1,5 +1,7 @@
 $_prefix = "PYS:"
 
+Write-Output "$_prefix VS Code installation"
+
 # Function to refresh environment variables in the current session
 function Refresh-Env {
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
@@ -44,50 +46,45 @@ if ( $vsc_paths.Count -gt 0 ) {
 
     Write-Output "$_prefix Downloading installer for Visual Studio Code..."
     Invoke-WebRequest -Uri $vscodeUrl -OutFile $vscodeInstallerPath
-    if ($?) {
-        Write-Output "$_prefix VS Code installer downloaded."
-    } else {
+    if (-not $?) {
         Exit-Message
     }
 
     Write-Output "$_prefix Installing Visual Studio Code..."
     # Install VS Code
     Start-Process -FilePath $vscodeInstallerPath -ArgumentList "/verysilent /norestart /mergetasks=!runcode" -Wait
-    if ($?) {
-        Write-Output "$_prefix VS Code installed."
-    } else {
+    if (-not $?) {
         Exit-Message
     }
 }
 
 # Refresh environment variables
+Write-Output "$_prefix Updating environment variables"
 Refresh-Env
-if ($?) {
-    Write-Output "$_prefix Environment variables refreshed."
-} else {
+if (-not $?) {
     Exit-Message
 }
+
+Clear-Host
+
 
 Write-Output "$_prefix Installing extensions for Visual Studio Code"
-# Install VS Code extensions
+
+# install python extension
 code --install-extension ms-python.python
-if ($?) {
-    Write-Output "$_prefix Python extension installed."
-} else {
+if (-not $?) {
     Exit-Message
 }
 
+#jupyter extension
 code --install-extension ms-toolsai.jupyter
-if ($?) {
-    Write-Output "$_prefix Jupyter extension installed."
-} else {
+if (-not $?) {
     Exit-Message
 }
 
+#pdf extension (for viewing pdfs inside vs code)
 code --install-extension tomoki1207.pdf
-if ($?) {
-    Write-Output "$_prefix PDF extension installed."
-} else {
+if (-not $?) {
     Exit-Message
 }
 

--- a/Windows_AutoInstall.ps1
+++ b/Windows_AutoInstall.ps1
@@ -1,3 +1,4 @@
+# Define the prefix variable
 $_prefix = "PYS:"
 
 # checks for environmental variables for remote and branch

--- a/Windows_AutoInstall.ps1
+++ b/Windows_AutoInstall.ps1
@@ -10,7 +10,7 @@ if (-not $env:BRANCH_PS) {
 
 $url_ps = "https://raw.githubusercontent.com/$env:REMOTE_PS/$env:BRANCH_PS/Windows"
 
-Write-Output "$_prefix: URL used for fetching scripts $url_ps"
+Write-Output "$_prefix URL used for fetching scripts $url_ps"
 
 PowerShell -ExecutionPolicy Bypass -Command "& {Invoke-Expression (Invoke-WebRequest -Uri '$url_ps/Python/Install.ps1' -UseBasicParsing).Content}"
 $_python_ret = $?

--- a/Windows_AutoInstall.ps1
+++ b/Windows_AutoInstall.ps1
@@ -1,4 +1,6 @@
+$_prefix = "PYS:"
 
+# checks for environmental variables for remote and branch
 if (-not $env:REMOTE_PS) {
     $env:REMOTE_PS = "dtudk/pythonsupport-scripts"
 }
@@ -6,22 +8,34 @@ if (-not $env:BRANCH_PS) {
     $env:BRANCH_PS = "main"
 }
 
+$url_ps = "https://raw.githubusercontent.com/$env:REMOTE_PS/$env:BRANCH_PS/Windows"
 
-$url_ps =  "https://raw.githubusercontent.com/$env:REMOTE_PS/$env:BRANCH_PS/Windows"
+Write-Output "$_prefix: URL used for fetching scripts $url_ps"
 
-
-Write-Output "Path before invoking webrequests: $url_ps"
-
-
-Write-Output "Running Windows_python.ps1"
-# link to full python installation 
 PowerShell -ExecutionPolicy Bypass -Command "& {Invoke-Expression (Invoke-WebRequest -Uri '$url_ps/Python/Install.ps1' -UseBasicParsing).Content}"
+$_python_ret = $?
 
-
-Write-Output "Running Windows_VSC.ps1"
-# link to full VSC installation
 PowerShell -ExecutionPolicy Bypass -Command "& {Invoke-Expression (Invoke-WebRequest -Uri '$url_ps/VSC/Install.ps1' -UseBasicParsing).Content}"
+$_vsc_ret = $?
 
+
+function Exit-Message {
+    Write-Output ""
+    Write-Output "Something went wrong in one of the installation runs."
+    Write-Output "Please see further up in the output for an error message..."
+    Write-Output ""
+}
+
+if ( -not $_python_ret ) {
+  Exit-Message
+  exit $_python_ret
+} elseif ( -not $_vsc_ret ) {
+  Exit-Message
+  exit $_vsc_ret
+}
+
+# Remove output
+Clear-Host
 
 Write-Output ""
 Write-Output "Script has finished. You may now close the terminal..."

--- a/Windows_AutoInstall.ps1
+++ b/Windows_AutoInstall.ps1
@@ -35,8 +35,6 @@ if ( -not $_python_ret ) {
   exit $_vsc_ret
 }
 
-# Remove output
-Clear-Host
-
+Write-Output ""
 Write-Output ""
 Write-Output "Script has finished. You may now close the terminal..."


### PR DESCRIPTION
Now the Mac and Win installation procedures are
better aligned. They should print, more or less,
the same thing. And they should both be able to obey the returned return code from the sub-shell that
gets invoked from the AutoInstall.

These can be more or less important, so probably
there should be some kind of guard against these
things.