### PR TITLE
Add support for downloading and installing Visual Studio Code for ARM64 computers

### DIFF
--- a/Windows/VSC/Install.ps1
+++ b/Windows/VSC/Install.ps1
@@ -41,7 +41,11 @@ if ( $vsc_paths.Count -gt 0 ) {
     Write-Output "$_prefix Visual Studio Code is already installed. Skipping VS Code installation.."
 } else {
     # Download the VS Code installer
-    $vscodeUrl = "https://update.code.visualstudio.com/latest/win32-x64-user/stable"
+    switch($ENV:PROCESSOR_ARCHITECTURE) {
+        "ARM64" { $vscodeUrl = "https://update.code.visualstudio.com/latest/win32-arm64-user/stable" }
+        default { $vscodeUrl = "https://update.code.visualstudio.com/latest/win32-x64-user/stable" }
+    }
+    
     $vscodeInstallerPath = "$env:USERPROFILE\Downloads\vscode-installer.exe"
 
     Write-Output "$_prefix Downloading installer for Visual Studio Code..."


### PR DESCRIPTION
This pull adds a switch statement in the powershell script in order to determine if the ARM64 installer should be used for installing Visual Studio Code on ARM windows machines.