### PR TITLE
Remove releases and add direct download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 ### macOS
 
 **Option 1: Download and Run (Recommended)** - Download the GUI installer:
-```bash
-curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/releases/dtu-python-installer-macos-gui.sh -o dtu-python-installer-macos.sh && chmod +x dtu-python-installer-macos.sh && ./dtu-python-installer-macos.sh
-```
+- [Download macOS GUI Installer](https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/releases/dtu-python-installer-macos-gui.sh)
+- Download the file, then double-click to run
 
 **Option 2: GUI Mode** - Uses native macOS authentication dialogs:
 ```bash
@@ -21,9 +20,8 @@ curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Ma
 ### Windows
 
 **Option 1: Download and Run (Recommended)** - Download the Windows GUI installer:
-```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Windows/releases/dtu-python-installer-windows-gui.bat" -OutFile "dtu-python-installer-windows.bat"; .\dtu-python-installer-windows.bat
-```
+- [Download Windows GUI Installer](https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Windows/releases/dtu-python-installer-windows-gui.bat)
+- Download the file, then double-click to run
 
 **Option 2: PowerShell** - Uses native Windows UAC authentication:
 ```powershell

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 
 ### macOS
 
-**Option 1: Download and Run (Recommended)** - See [latest release](https://github.com/dtudk/pythonsupport-scripts/releases/latest) for GUI installer.
+**Option 1: Download and Run (Recommended)** - Download the GUI installer:
+```bash
+curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/releases/dtu-python-installer-macos-gui.sh -o dtu-python-installer-macos.sh && chmod +x dtu-python-installer-macos.sh && ./dtu-python-installer-macos.sh
+```
 
 **Option 2: GUI Mode** - Uses native macOS authentication dialogs:
 ```bash
@@ -17,7 +20,10 @@ curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Ma
 
 ### Windows
 
-**Option 1: Download and Run (Recommended)** - See [latest release](https://github.com/dtudk/pythonsupport-scripts/releases/latest) for Windows GUI installer.
+**Option 1: Download and Run (Recommended)** - Download the Windows GUI installer:
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Windows/releases/dtu-python-installer-windows-gui.bat" -OutFile "dtu-python-installer-windows.bat"; .\dtu-python-installer-windows.bat
+```
 
 **Option 2: PowerShell** - Uses native Windows UAC authentication:
 ```powershell


### PR DESCRIPTION
Remove GitHub releases and update README with simple download links.

**Changes:**
- Deleted GitHub releases: v1.0.0-gui-wrapper and v1.0.0-windows-gui-wrapper
- Removed git tags for the releases
- Updated README.md to use direct download links instead of release links

**New Download Options:**
- **macOS**: [Download macOS GUI Installer](https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/releases/dtu-python-installer-macos-gui.sh)
- **Windows**: [Download Windows GUI Installer](https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/Windows/releases/dtu-python-installer-windows-gui.bat)

**User Experience:**
- Users can now simply click the download links
- No need to run terminal commands to download
- Download the file, then double-click to run
- Much simpler and more user-friendly