### PR TITLE
feat: Add helpful password message for sudo prompts in CLI mode

### DIFF
--- a/MacOS/Components/Core/uninstall_conda.sh
+++ b/MacOS/Components/Core/uninstall_conda.sh
@@ -36,6 +36,7 @@ remove_conda_installation() {
             if [ "$needs_sudo" = true ]; then
                 if [[ "${CLI_MODE:-}" == "true" ]]; then
                     # CLI mode - use sudo directly
+                    echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
                     if sudo -E bash "$conda_path/uninstall.sh" --yes; then
                         echo "$conda_type uninstaller completed successfully"
                         return 0
@@ -68,6 +69,7 @@ remove_conda_installation() {
         if [ "$needs_sudo" = true ]; then
             if [[ "${CLI_MODE:-}" == "true" ]]; then
                 # CLI mode - use sudo directly
+                echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
                 sudo rm -rf "$conda_path"
             else
                 # GUI mode - use osascript for native authentication
@@ -145,6 +147,7 @@ if command -v conda >/dev/null 2>&1; then
         conda init --reverse --all 2>/dev/null || echo "conda init --reverse failed, using manual cleanup"
     elif [[ "${CLI_MODE:-}" == "true" ]]; then
         # CLI mode - use sudo directly
+        echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
         sudo -E conda init --reverse --all 2>/dev/null || echo "conda init --reverse failed, using manual cleanup"
     else
         # GUI mode - use osascript for native authentication

--- a/MacOS/Components/VSC/install.sh
+++ b/MacOS/Components/VSC/install.sh
@@ -43,6 +43,7 @@ elif [ -d "/Applications/Visual Studio Code.app" ]; then
             export PATH="$HOME/bin:$PATH"
         elif [[ "${CLI_MODE:-}" == "true" ]]; then
             # CLI mode - use sudo directly
+            echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
             sudo ln -sf "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" /usr/local/bin/code 2>/dev/null || true
         else
             # GUI mode - use osascript for native authentication
@@ -109,6 +110,7 @@ else
         export PATH="$HOME/bin:$PATH"
     elif [[ "${CLI_MODE:-}" == "true" ]]; then
         # CLI mode - use sudo directly
+        echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
         sudo mkdir -p /usr/local/bin 2>/dev/null || true
         sudo ln -sf "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" /usr/local/bin/code 2>/dev/null || true
     else

--- a/MacOS/Components/VSC/uninstall_vscode.sh
+++ b/MacOS/Components/VSC/uninstall_vscode.sh
@@ -26,6 +26,7 @@ remove_vscode_application() {
         if [ "$needs_sudo" = true ]; then
             if [[ "${CLI_MODE:-}" == "true" ]]; then
                 # CLI mode - use sudo directly
+                echo "Please enter the password to your computer to continue (you will not be able to see what you type)"
                 sudo rm -rf "$app_path"
             else
                 # GUI mode - use osascript for native authentication


### PR DESCRIPTION
This PR adds a helpful password message before all sudo commands in CLI mode to improve user experience during installation.

## Changes
- Add 'Please enter the password to your computer to continue (you will not be able to see what you type)' message before all sudo commands in CLI mode
- Covers uninstall_conda.sh (3 locations), VS Code install.sh (2 locations), and uninstall_vscode.sh (1 location)
- Improves user experience during installation when administrator privileges are required

## Files Modified
- MacOS/Components/Core/uninstall_conda.sh
- MacOS/Components/VSC/install.sh  
- MacOS/Components/VSC/uninstall_vscode.sh