### PR TITLE
VS code download URL update

### DIFF
--- a/MacOS/Components/VSC/install.sh
+++ b/MacOS/Components/VSC/install.sh
@@ -64,9 +64,9 @@ else
     ARCH=$(uname -m)
     echo "Detected architecture: $ARCH"
     if [[ "$ARCH" == "arm64" ]]; then
-        VSCODE_URL="https://code.visualstudio.com/sha/download?build=stable&os=darwin-arm64"
+        VSCODE_URL="https://update.code.visualstudio.com/latest/darwin-arm64/stable"
     else
-        VSCODE_URL="https://code.visualstudio.com/sha/download?build=stable&os=darwin"
+        VSCODE_URL="https://update.code.visualstudio.com/latest/darwin/stable"
     fi
     
     echo "Downloading VS Code from: $VSCODE_URL"


### PR DESCRIPTION
It seems like Microsoft must have changed something with their VS code download URLs as now all the mac users trying to use the script are getting 404 errors during the VS code installation stage. 

Here is an updated version that uses the new URLs provided by them. 

Needs testing on a mac tho.